### PR TITLE
Removing min="" attribute from input fields

### DIFF
--- a/views/my-stats.twig
+++ b/views/my-stats.twig
@@ -32,7 +32,7 @@ enlightened-agent{% endif %}
 	{% endif %}
 		<tr>
 			<td>{{ stat.name }}</td>
-			<td><input type="number" name="{{ stat.stat }}" value="{{ attribute(agent.stats, stat.stat) }}" min="{{ attribute(agent.stats, stat.stat) }}" /></td>
+			<td><input type="number" name="{{ stat.stat }}" value="{{ attribute(agent.stats, stat.stat) }}" /></td>
 		</tr>
 {% endfor %}
 		<tr>


### PR DESCRIPTION
NIA pushed an update that caused stats (at least xm_collected) to drop significantly for agents. Removing this attribute will mitigate that for the time being
