### PR TITLE
Include 'Mentoring' in OCR processing. Oops. Fixes #99

### DIFF
--- a/src/BlueHerons/StatTracker/OCR.php
+++ b/src/BlueHerons/StatTracker/OCR.php
@@ -432,6 +432,10 @@ class OCR {
                     $count++;
                     array_push($elements, $values[1]);
                 }
+                elseif ($step == 'mentoring' && preg_match('/^\s*([\d\s\|.aegiloqt,]+)\s*$/sxmi', $line, $values)) {
+                    array_push($elements, $values[1]);
+                }
+
             }
 
             // final check on count


### PR DESCRIPTION
Heh, whoops. Forgot to process the OCR'd value for "Mentoring"