### PR TITLE
Allow access to settings without submitting stats. Fixes #127

### DIFF
--- a/resources/scripts/stat-tracker.js.twig
+++ b/resources/scripts/stat-tracker.js.twig
@@ -55,7 +55,7 @@ var StatTracker = new function() {
                 }
                 else if (result.status == "okay") {
                     $("#login-dialog").hide();
-                    if (!result.agent.has_submitted) {
+                    if (!result.agent.has_submitted && StatTracker.pageToLoad != "settings") {
                         StatTracker.message = "Stats must be submitted before this tool can be utilized.";
                         StatTracker.pageToLoad = "submit-stats";
                     }

--- a/views/settings.twig
+++ b/views/settings.twig
@@ -15,7 +15,7 @@
                             <th>Actions</th>
                         </tr>
                     </table>
-                    <p class="small-text">Note: the "API" token cannot be truly revoked, it is used to access your data through the website. If you revoke it, a new one will be generated and you will need to log in again.</p>
+                    <p class="small-text">Note: the "WEBAPP" token cannot be truly revoked, it is used to access your data through the website. If you revoke it, a new one will be generated and you will need to log in again.</p>
 
 		</div>
 	</div>


### PR DESCRIPTION
Allow access to the settings page to generate a token an such before submitting stats for the first time.