### PR TITLE
Handle "null" days remainig in predictions.

### DIFF
--- a/resources/scripts/stat-tracker.js.twig
+++ b/resources/scripts/stat-tracker.js.twig
@@ -114,7 +114,12 @@ var StatTracker = new function() {
 };
 
 var format = function(number) {
-    return numeral(number).format("0,0.[00]");
+    if (number == null || number == undefined) {
+        return "&#8734;"
+    }
+    else {
+        return numeral(number).format("0,0.[00]");
+    }
 }
 
 var hasLocalStorage = function() {


### PR DESCRIPTION
Previously "null" days remainings would translate as 0, which is technically incorrect. Fixes #119 